### PR TITLE
Fix VPP-923 enhancing trace tool by adding filtering

### DIFF
--- a/src/vlib/trace.h
+++ b/src/vlib/trace.h
@@ -89,6 +89,22 @@ typedef struct
   int verbose;
 } vlib_trace_main_t;
 
+typedef struct
+{
+  /* Index of the node where the filter data is stored */
+  u32 node_index;
+
+  /* Offset in header data of where it is */
+  u32 offset;
+
+  /* Size of data in header */
+  u32 size;
+  
+  /* Data to filter on */
+  u8 data[16];
+  
+} vlib_show_trace_filter_t;
+
 #endif /* included_vlib_trace_h */
 
 /*


### PR DESCRIPTION
Implementation of trace filtering in  https://jira.fd.io/browse/VPP-923. This lets you filter on a subset of attributes, these are:
- source IP (IPv4 & IPv6)
- destination IP (IPv4 & IPv6)
- source port
- destination port
- protocol

It could be extended in the future to support more attributes if that was desirable.

The trace data is built up by each node adding data it feels important to record rather than just capturing the packets themselves. This limits the way this can be implemented to searching through each node's data until it finds a node which recorded the information to search on. I think it'd be interesting to performance test it, however I'm not expecting great performance. Hopefully that doesn't matter as the cost is not in the dataplane.